### PR TITLE
Feature/ Change coin type to default

### DIFF
--- a/app/params/params.go
+++ b/app/params/params.go
@@ -2,7 +2,14 @@ package params
 
 // App Parameters
 const (
-	DefaultBondDenom = "usge"
+	// HumanCoinUnit is human readable representation of the coin name
+	HumanCoinUnit = "sge"
+	// BaseCoinUnit is the actual name of coin used in transaction
+	BaseCoinUnit = "usge"
+	// SGEExponent is the exponential digits of the coin
+	SGEExponent = 6
+	// DefaultBondDenom is the default staking denom of application
+	DefaultBondDenom = BaseCoinUnit
 )
 
 // Simulation parameter constants

--- a/app/prefix.go
+++ b/app/prefix.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sge-network/sge/app/params"
 )
 
 const (
@@ -20,14 +21,6 @@ var (
 	ConsNodeAddressPrefix = AccountAddressPrefix + "valcons"
 	// ConsNodePubKeyPrefix used for generating consensus node public key
 	ConsNodePubKeyPrefix = AccountAddressPrefix + "valconspub"
-	// CoinType is the SGE coin type as defined in SLIP44 (https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
-	CoinType uint32 = 909
-	// Purpose is the purpose of the BIP44
-	Purpose uint32 = 44
-	// FullFundraiserPath is the parts of the BIP44 HD path that are fixed by
-	// what we used during the SGE fundraiser.
-	// More info (https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
-	FullFundraiserPath = "m/44'/909'/0'/0/0"
 )
 
 // SetConfig sets prefixes configuration
@@ -36,9 +29,15 @@ func SetConfig() {
 	config.SetBech32PrefixForAccount(AccountAddressPrefix, AccountPubKeyPrefix)
 	config.SetBech32PrefixForValidator(ValidatorAddressPrefix, ValidatorPubKeyPrefix)
 	config.SetBech32PrefixForConsensusNode(ConsNodeAddressPrefix, ConsNodePubKeyPrefix)
-	config.SetCoinType(CoinType)
-	config.SetPurpose(Purpose)
-	// nolint
-	config.SetFullFundraiserPath(FullFundraiserPath)
+
+	err := sdk.RegisterDenom(params.HumanCoinUnit, sdk.OneDec())
+	if err != nil {
+		panic(err)
+	}
+	err = sdk.RegisterDenom(params.BaseCoinUnit, sdk.NewDecWithPrec(1, params.SGEExponent))
+	if err != nil {
+		panic(err)
+	}
+
 	config.Seal()
 }


### PR DESCRIPTION
## Description

Currently, Most of the apps In the industry use the default coin type (118) as their application coin type. This helps the application be compatible with IBC and generic wallet support.

---

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Added Features

- [x] Change coin type to 118
- [x] Remove `FullFundRaiserPath`
- [x] Register `sge` and `usge` in the app config

---

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
---
