### PR TITLE
Fix / Panic in the end blocker logic

### DIFF
--- a/x/bet/abci.go
+++ b/x/bet/abci.go
@@ -11,6 +11,6 @@ import (
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	err := k.BatchSportEventSettlements(ctx)
 	if err != nil {
-		k.Logger(ctx).Error(fmt.Sprintf("end block no %d failed : %s", ctx.BlockHeight(), err.Error()))
+		panic(fmt.Sprintf("end block no %d failed : %s", ctx.BlockHeight(), err.Error()))
 	}
 }

--- a/x/orderbook/abci.go
+++ b/x/orderbook/abci.go
@@ -11,6 +11,6 @@ import (
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	err := k.BatchOrderBookSettlements(ctx)
 	if err != nil {
-		k.Logger(ctx).Error(fmt.Sprintf("end block no %d failed : %s", ctx.BlockHeight(), err.Error()))
+		panic(fmt.Sprintf("end block no %d failed : %s", ctx.BlockHeight(), err.Error()))
 	}
 }

--- a/x/orderbook/keeper/orderbook_settle.go
+++ b/x/orderbook/keeper/orderbook_settle.go
@@ -52,13 +52,14 @@ func (k Keeper) batchSettlementOfDeposit(ctx sdk.Context, orderBookUID string, c
 	allSettled, settled := true, 0
 	bookParticipations, err := k.GetParticipationsOfBook(ctx, orderBookUID)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("batch settlement of book %s failed: %s", orderBookUID, err)
 	}
 	for _, bookParticipation := range bookParticipations {
 		if !bookParticipation.IsSettled {
 			err = k.settleDeposit(ctx, bookParticipation)
 			if err != nil {
-				return allSettled, err
+				return allSettled, fmt.Errorf("failed to settle deposit of batch settlement for participation %#v: %s",
+					bookParticipation, err)
 			}
 			settled++
 			allSettled = false


### PR DESCRIPTION
## Description

The automated processing in the `end_block` should be error-free otherwise we have a critical problem in the blockchain state or logic of the application. so ti should panic and prevent the continuation of running the application with error.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Modified Features

- [x] End blocker errors
- [x] Modify errors to be trackable by panic message.

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
---
