### PR TITLE
Fix/ Negative coin in order book bet placement calculations

### DIFF
--- a/proto/sge/orderbook/participation.proto
+++ b/proto/sge/orderbook/participation.proto
@@ -28,7 +28,6 @@ message BookParticipation {
   // if participation is a module account
   bool is_module_account = 4
       [ (gogoproto.moretags) = "yaml:\"is_module_account\"" ];
-  ;
 
   // liquidity is the total initial liquidity provided
   string liquidity = 5 [
@@ -95,7 +94,6 @@ message BookParticipation {
 
   // if participation is settled
   bool is_settled = 14 [ (gogoproto.moretags) = "yaml:\"is_settled\"" ];
-  ;
 }
 
 // ParticipationBetPair represents the book participation and bet bond

--- a/x/bet/types/errors.go
+++ b/x/bet/types/errors.go
@@ -33,7 +33,7 @@ var (
 	ErrInConvertingOddsToDec                = sdkerrors.Register(ModuleName, 2022, "internal error in converting odds value from string to sdk.Dec")
 	ErrInConvertingOddsToInt                = sdkerrors.Register(ModuleName, 2023, "internal error in converting odds value from string to sdk.Int")
 	ErrOddsDataNotFound                     = sdkerrors.Register(ModuleName, 2024, "odds does not exist in ticket payload")
-	ErrInvalidOddsType                      = sdkerrors.Register(ModuleName, 2025, "valid odds type should be provided, 1: decimal, 2: fractional, 3: monyline")
+	ErrInvalidOddsType                      = sdkerrors.Register(ModuleName, 2025, "valid odds type should be provided, 1: decimal, 2: fractional, 3: moneyline")
 	ErrUserKycFailed                        = sdkerrors.Register(ModuleName, 2026, "the bettor failed the KYC Validation")
 	ErrCanNotQueryLargeNumberOfBets         = sdkerrors.Register(ModuleName, 2027, "can not query more than "+cast.ToString(MaxAllowedQueryBetsCount))
 	ErrDecimalOddsShouldBePositive          = sdkerrors.Register(ModuleName, 2028, "decimal odds value should be positive")

--- a/x/bet/types/odds_type.go
+++ b/x/bet/types/odds_type.go
@@ -35,7 +35,7 @@ func (c *decimalOdds) CalculatePayout(oddsVal string, amount sdk.Int) (sdk.Int, 
 	}
 
 	// odds value should not be less than 1
-	if oddsDecVal.LTE(sdk.NewDec(1)) {
+	if oddsDecVal.LTE(sdk.OneDec()) {
 		return sdk.ZeroInt(),
 			sdkerrors.Wrapf(ErrDecimalOddsCanNotBeLessThanOne, "%s", oddsVal)
 	}
@@ -63,7 +63,7 @@ func (c *decimalOdds) CalculateBetAmount(oddsVal string, payoutProfit sdk.Int) (
 	}
 
 	// odds value should not be less than 1
-	if oddsDecVal.LT(sdk.NewDec(1)) {
+	if oddsDecVal.LTE(sdk.OneDec()) {
 		return sdk.ZeroInt(),
 			sdkerrors.Wrapf(ErrDecimalOddsCanNotBeLessThanOne, "%s", oddsVal)
 	}
@@ -153,7 +153,7 @@ func (c *fractionalOdds) CalculateBetAmount(oddsVal string, payoutProfit sdk.Int
 	coefficient := firstPart.ToDec().Quo(secondPart.ToDec())
 
 	// calculate bet amount
-	betAmount := payoutProfit.ToDec().Quo(coefficient.Sub(sdk.OneDec()))
+	betAmount := payoutProfit.ToDec().Quo(coefficient)
 
 	// get the integer part of the bet amount
 	return betAmount.RoundInt(), nil
@@ -219,7 +219,7 @@ func (c *moneylineOdds) CalculateBetAmount(oddsVal string, payoutProfit sdk.Int)
 	}
 
 	// calculate bet amount
-	betAmount := payoutProfit.ToDec().Quo(coefficient.Sub(sdk.OneDec()))
+	betAmount := payoutProfit.ToDec().Quo(coefficient)
 
 	// get the integer part of the bet amount
 	return betAmount.RoundInt(), nil

--- a/x/bet/types/payout_test.go
+++ b/x/bet/types/payout_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var ecceptedTruncatedValue = sdk.NewInt(7)
+
 var defaultBetAmount = int64(35625789)
 
 func TestCalculateDecimalPayout(t *testing.T) {
@@ -59,6 +61,14 @@ func TestCalculateDecimalPayout(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, sdk.NewInt(tc.expVal).Equal(payout), "expected: %d, actual: %d", tc.expVal, payout.Int64())
 			}
+
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_DECIMAL, tc.oddsValue, payout)
+			if tc.err != nil {
+				require.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount).LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount.Int64())
+			}
 		})
 	}
 }
@@ -80,21 +90,21 @@ func TestCalculateFractionalPayout(t *testing.T) {
 			expVal: 89064473,
 		},
 		{
-			desc:      "positive outcome",
+			desc:      "positive outcome 1",
 			oddsValue: "7/2",
 			betAmount: defaultBetAmount,
 
 			expVal: 124690261,
 		},
 		{
-			desc:      "negative outcome",
+			desc:      "positive outcome 2",
 			oddsValue: "2/7",
 			betAmount: defaultBetAmount,
 
 			expVal: 10178797,
 		},
 		{
-			desc:      "negative outcome",
+			desc:      "positive outcome 3",
 			oddsValue: "1/17",
 			betAmount: defaultBetAmount,
 
@@ -166,6 +176,14 @@ func TestCalculateFractionalPayout(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.True(t, sdk.NewInt(tc.expVal).Equal(payout), "expected: %d, actual: %d", tc.expVal, payout.Int64())
+			}
+
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_FRACTIONAL, tc.oddsValue, payout)
+			if tc.err != nil {
+				require.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount.Int64())
 			}
 		})
 	}
@@ -239,6 +257,14 @@ func TestCalculateMoneylinePayout(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.True(t, sdk.NewInt(tc.expVal).Equal(payout), "expected: %d, actual: %d", tc.expVal, payout.Int64())
+			}
+
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_MONEYLINE, tc.oddsValue, payout)
+			if tc.err != nil {
+				require.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount.Int64())
 			}
 		})
 	}


### PR DESCRIPTION
## Description

The Calculated payout from the payout profit is being wrong for `fractional` and `moneyline`.
**NOTE**: there is as well a rounding truncated value for the calculation.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Modified Features

- [x] Fractional bet amount calculation from payout profit
- [x] Moneyline bet amount calculation from payout profit

---

## Test Cases

- [x] `TestCalculateDecimalPayout`
- [x] `TestCalculateFractionalPayout`
- [x] `TestCalculateMoneylinePayout`

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
---
