### PR TITLE
Fix / Truncation of payout calculation

### DIFF
--- a/x/bet/keeper/settle_bet.go
+++ b/x/bet/keeper/settle_bet.go
@@ -52,12 +52,12 @@ func (k Keeper) SettleBet(ctx sdk.Context, bettorAddressStr, betUID string) erro
 		sportEvent.Status == sporteventtypes.SportEventStatus_SPORT_EVENT_STATUS_CANCELED {
 		bet.Result = types.Bet_RESULT_ABORTED
 
-		payout, err := types.CalculatePayoutProfit(bet.OddsType, bet.OddsValue, bet.Amount)
+		payoutProfit, err := types.CalculatePayoutProfit(bet.OddsType, bet.OddsValue, bet.Amount)
 		if err != nil {
 			return err
 		}
 
-		if err := k.obKeeper.RefundBettor(ctx, bettorAddress, bet.Amount, payout, bet.UID); err != nil {
+		if err := k.obKeeper.RefundBettor(ctx, bettorAddress, bet.Amount, payoutProfit.TruncateInt(), bet.UID); err != nil {
 			return sdkerrors.Wrapf(types.ErrInSRRefund, "%s", err)
 		}
 
@@ -111,12 +111,12 @@ func (k Keeper) settleResolvedBet(ctx sdk.Context, bet *types.Bet) error {
 	}
 
 	if bet.Result == types.Bet_RESULT_LOST {
-		if err := k.obKeeper.BettorLoses(ctx, bettorAddress, bet.Amount, payout, bet.UID, bet.BetFulfillment, bet.SportEventUID); err != nil {
+		if err := k.obKeeper.BettorLoses(ctx, bettorAddress, bet.Amount, payout.TruncateInt(), bet.UID, bet.BetFulfillment, bet.SportEventUID); err != nil {
 			return sdkerrors.Wrapf(types.ErrInSRBettorLoses, "%s", err)
 		}
 		bet.Status = types.Bet_STATUS_SETTLED
 	} else if bet.Result == types.Bet_RESULT_WON {
-		if err := k.obKeeper.BettorWins(ctx, bettorAddress, bet.Amount, payout, bet.UID, bet.BetFulfillment, bet.SportEventUID); err != nil {
+		if err := k.obKeeper.BettorWins(ctx, bettorAddress, bet.Amount, payout.TruncateInt(), bet.UID, bet.BetFulfillment, bet.SportEventUID); err != nil {
 			return sdkerrors.Wrapf(types.ErrInSRBettorWins, "%s", err)
 		}
 		bet.Status = types.Bet_STATUS_SETTLED

--- a/x/bet/types/expected_keepers.go
+++ b/x/bet/types/expected_keepers.go
@@ -35,7 +35,7 @@ type DVMKeeper interface {
 
 // OrderBookKeeper defines the expected interface needed to process bet placement
 type OrderBookKeeper interface {
-	ProcessBetPlacement(ctx sdk.Context, uniqueLock, bookUID, oddsUID string, maxLossMultiplier sdk.Dec, payoutProfit sdk.Int, bettorAddress sdk.AccAddress, betFee sdk.Int, oddsType OddsType, oddsVal string, betID uint64) ([]*BetFulfillment, error)
+	ProcessBetPlacement(ctx sdk.Context, betUID, bookUID, oddsUID string, maxLossMultiplier sdk.Dec, payoutProfit sdk.Dec, bettorAddress sdk.AccAddress, betFee sdk.Int, oddsType OddsType, oddsVal string, betID uint64) ([]*BetFulfillment, error)
 	RefundBettor(ctx sdk.Context, bettorAddress sdk.AccAddress, betAmount, payout sdk.Int, uniqueLock string) error
 	BettorWins(ctx sdk.Context, bettorAddress sdk.AccAddress, betAmount, payout sdk.Int, uniqueLock string, fulfillment []*BetFulfillment, bookUID string) error
 	BettorLoses(ctx sdk.Context, bettorAddress sdk.AccAddress, betAmount, payout sdk.Int, uniqueLock string, fulfillment []*BetFulfillment, bookUID string) error

--- a/x/bet/types/payout.go
+++ b/x/bet/types/payout.go
@@ -3,20 +3,20 @@ package types
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
 // CalculatePayoutProfit calculates the amount of payout profit portion according to bet odds value and amount
-func CalculatePayoutProfit(oddsType OddsType, oddsVal string, amount sdk.Int) (sdk.Int, error) {
+func CalculatePayoutProfit(oddsType OddsType, oddsVal string, amount sdk.Int) (sdk.Dec, error) {
 	payout, err := calculatePayout(oddsType, oddsVal, amount)
 	if err != nil {
-		return sdk.ZeroInt(), err
+		return sdk.ZeroDec(), err
 	}
 
 	// bettor profit is the subtracted amount of payout from bet amount
-	profit := payout.Sub(amount)
+	profit := payout.Sub(amount.ToDec())
 
 	return profit, nil
 }
 
 // calculatePayout calculates the amount of payout according to bet odds value and amount
-func calculatePayout(oddsType OddsType, oddsVal string, amount sdk.Int) (sdk.Int, error) {
+func calculatePayout(oddsType OddsType, oddsVal string, amount sdk.Int) (sdk.Dec, error) {
 	var oType OddsTypeI
 
 	// assign corresponding type to the interface instance
@@ -31,30 +31,30 @@ func calculatePayout(oddsType OddsType, oddsVal string, amount sdk.Int) (sdk.Int
 		oType = new(moneylineOdds)
 
 	default:
-		return sdk.ZeroInt(), ErrInvalidOddsType
+		return sdk.ZeroDec(), ErrInvalidOddsType
 	}
 
 	// total payout should be paid to bettor
 	payout, err := oType.CalculatePayout(oddsVal, amount)
 	if err != nil {
-		return sdk.ZeroInt(), err
+		return sdk.ZeroDec(), err
 	}
 
 	return payout, nil
 }
 
 // CalculateBetAmount calculates the amount of bet according to bet odds value and payout profit
-func CalculateBetAmount(oddsType OddsType, oddsVal string, payoutProfit sdk.Int) (sdk.Int, error) {
+func CalculateBetAmount(oddsType OddsType, oddsVal string, payoutProfit sdk.Dec) (sdk.Dec, error) {
 	betAmount, err := calculateBetAmount(oddsType, oddsVal, payoutProfit)
 	if err != nil {
-		return sdk.ZeroInt(), err
+		return sdk.ZeroDec(), err
 	}
 
 	return betAmount, nil
 }
 
 // calculateBetAmount calculates the amount of bet according to bet odds value and payoutProfit
-func calculateBetAmount(oddsType OddsType, oddsVal string, payoutProfit sdk.Int) (sdk.Int, error) {
+func calculateBetAmount(oddsType OddsType, oddsVal string, payoutProfit sdk.Dec) (sdk.Dec, error) {
 	var oType OddsTypeI
 
 	// assign corresponding type to the interface instance
@@ -69,13 +69,13 @@ func calculateBetAmount(oddsType OddsType, oddsVal string, payoutProfit sdk.Int)
 		oType = new(moneylineOdds)
 
 	default:
-		return sdk.ZeroInt(), ErrInvalidOddsType
+		return sdk.ZeroDec(), ErrInvalidOddsType
 	}
 
 	// total payout should be paid to bettor
 	betAmount, err := oType.CalculateBetAmount(oddsVal, payoutProfit)
 	if err != nil {
-		return sdk.ZeroInt(), err
+		return sdk.ZeroDec(), err
 	}
 
 	return betAmount, nil

--- a/x/bet/types/payout_test.go
+++ b/x/bet/types/payout_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ecceptedTruncatedValue = sdk.NewInt(7)
+var ecceptedTruncatedValue = sdk.NewInt(1)
 
 var defaultBetAmount = int64(35625789)
 
@@ -26,7 +26,7 @@ func TestCalculateDecimalPayout(t *testing.T) {
 			oddsValue: "1.55",
 			betAmount: defaultBetAmount,
 
-			expVal: 19594184,
+			expVal: 19594183,
 		},
 
 		{
@@ -54,20 +54,20 @@ func TestCalculateDecimalPayout(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			payout, err := types.CalculatePayoutProfit(types.OddsType_ODDS_TYPE_DECIMAL, tc.oddsValue, sdk.NewInt(tc.betAmount))
+			payoutProfit, err := types.CalculatePayoutProfit(types.OddsType_ODDS_TYPE_DECIMAL, tc.oddsValue, sdk.NewInt(tc.betAmount))
 			if tc.err != nil {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.expVal).Equal(payout), "expected: %d, actual: %d", tc.expVal, payout.Int64())
+				require.True(t, sdk.NewInt(tc.expVal).Equal(payoutProfit.TruncateInt()), "expected: %d, actual: %d", tc.expVal, payoutProfit)
 			}
 
-			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_DECIMAL, tc.oddsValue, payout)
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_DECIMAL, tc.oddsValue, payoutProfit)
 			if tc.err != nil {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount).LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount.Int64())
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount.Ceil().TruncateInt()).LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount)
 			}
 		})
 	}
@@ -87,7 +87,7 @@ func TestCalculateFractionalPayout(t *testing.T) {
 			oddsValue: "5/2",
 			betAmount: defaultBetAmount,
 
-			expVal: 89064473,
+			expVal: 89064472,
 		},
 		{
 			desc:      "positive outcome 1",
@@ -101,14 +101,14 @@ func TestCalculateFractionalPayout(t *testing.T) {
 			oddsValue: "2/7",
 			betAmount: defaultBetAmount,
 
-			expVal: 10178797,
+			expVal: 10178796,
 		},
 		{
 			desc:      "positive outcome 3",
 			oddsValue: "1/17",
 			betAmount: defaultBetAmount,
 
-			expVal: 2095635,
+			expVal: 2095634,
 		},
 		{
 			desc:      "same",
@@ -170,20 +170,20 @@ func TestCalculateFractionalPayout(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			payout, err := types.CalculatePayoutProfit(types.OddsType_ODDS_TYPE_FRACTIONAL, tc.oddsValue, sdk.NewInt(tc.betAmount))
+			payoutProfit, err := types.CalculatePayoutProfit(types.OddsType_ODDS_TYPE_FRACTIONAL, tc.oddsValue, sdk.NewInt(tc.betAmount))
 			if tc.err != nil {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.expVal).Equal(payout), "expected: %d, actual: %d", tc.expVal, payout.Int64())
+				require.True(t, sdk.NewInt(tc.expVal).Equal(payoutProfit.TruncateInt()), "expected: %d, actual: %d", tc.expVal, payoutProfit)
 			}
 
-			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_FRACTIONAL, tc.oddsValue, payout)
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_FRACTIONAL, tc.oddsValue, payoutProfit)
 			if tc.err != nil {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount.Int64())
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount.Ceil().RoundInt()).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount)
 			}
 		})
 	}
@@ -210,7 +210,7 @@ func TestCalculateMoneylinePayout(t *testing.T) {
 			oddsValue: "-450",
 			betAmount: defaultBetAmount,
 
-			expVal: 7916842,
+			expVal: 7916841,
 		},
 		{
 			desc:      "lower",
@@ -224,7 +224,7 @@ func TestCalculateMoneylinePayout(t *testing.T) {
 			oddsValue: "+450",
 			betAmount: defaultBetAmount,
 
-			expVal: 160316051,
+			expVal: 160316050,
 		},
 		{
 			desc:      "lower",
@@ -251,20 +251,20 @@ func TestCalculateMoneylinePayout(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			payout, err := types.CalculatePayoutProfit(types.OddsType_ODDS_TYPE_MONEYLINE, tc.oddsValue, sdk.NewInt(tc.betAmount))
+			payoutProfit, err := types.CalculatePayoutProfit(types.OddsType_ODDS_TYPE_MONEYLINE, tc.oddsValue, sdk.NewInt(tc.betAmount))
 			if tc.err != nil {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.expVal).Equal(payout), "expected: %d, actual: %d", tc.expVal, payout.Int64())
+				require.True(t, sdk.NewInt(tc.expVal).Equal(payoutProfit.TruncateInt()), "expected: %d, actual: %d", tc.expVal, payoutProfit)
 			}
 
-			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_MONEYLINE, tc.oddsValue, payout)
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_MONEYLINE, tc.oddsValue, payoutProfit)
 			if tc.err != nil {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount.Int64())
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount.Ceil().TruncateInt()).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount)
 			}
 		})
 	}

--- a/x/orderbook/keeper/participation.go
+++ b/x/orderbook/keeper/participation.go
@@ -144,53 +144,54 @@ func (k Keeper) InitiateBookParticipation(
 func (k Keeper) LiquidateBookParticipation(
 	ctx sdk.Context, depositorAddr, bookUID string, participationIndex uint64, mode housetypes.WithdrawalMode, amount sdk.Int,
 ) (sdk.Int, error) {
-	var withdrawalAmt sdk.Int
+
 	depositorAddress, err := sdk.AccAddressFromBech32(depositorAddr)
 	if err != nil {
-		return withdrawalAmt, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, types.ErrTextInvalidDesositor, err)
+		return sdk.Int{}, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, types.ErrTextInvalidDesositor, err)
 	}
 
 	bp, found := k.GetBookParticipation(ctx, bookUID, participationIndex)
 	if !found {
-		return withdrawalAmt, sdkerrors.Wrapf(types.ErrBookParticipationNotFound, "%s, %d", bookUID, participationIndex)
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrBookParticipationNotFound, "%s, %d", bookUID, participationIndex)
 	}
 
 	if bp.IsSettled {
-		return withdrawalAmt, sdkerrors.Wrapf(types.ErrBookParticipationAlreadySettled, "%s, %d", bookUID, participationIndex)
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrBookParticipationAlreadySettled, "%s, %d", bookUID, participationIndex)
 	}
 
 	if bp.ParticipantAddress != depositorAddr {
-		return withdrawalAmt, sdkerrors.Wrapf(types.ErrMismatchInDepositorAddress, "%s", bp.ParticipantAddress)
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrMismatchInDepositorAddress, "%s", bp.ParticipantAddress)
 	}
 
 	if bp.IsModuleAccount {
-		return withdrawalAmt, sdkerrors.Wrapf(types.ErrDepositorIsModuleAccount, "%s", bp.ParticipantAddress)
+		return sdk.Int{}, sdkerrors.Wrapf(types.ErrDepositorIsModuleAccount, "%s", bp.ParticipantAddress)
 	}
 
 	// Calculate max amount that can be transferred
 	maxTransferableAmount := bp.CurrentRoundLiquidity.Sub(bp.CurrentRoundMaxLoss)
 
+	var withdrawalAmt sdk.Int
 	switch mode {
 	case housetypes.WithdrawalMode_WITHDRAWAL_MODE_FULL:
 		if maxTransferableAmount.LTE(sdk.ZeroInt()) {
-			return withdrawalAmt, sdkerrors.Wrapf(types.ErrMaxWithdrawableAmountIsZero, "%d, %d", bp.CurrentRoundLiquidity.Int64(), bp.CurrentRoundMaxLoss.Int64())
+			return sdk.Int{}, sdkerrors.Wrapf(types.ErrMaxWithdrawableAmountIsZero, "%d, %d", bp.CurrentRoundLiquidity, bp.CurrentRoundMaxLoss)
 		}
 		err := k.transferFundsFromModuleToUser(ctx, types.BookLiquidityName, depositorAddress, maxTransferableAmount)
 		if err != nil {
-			return withdrawalAmt, err
+			return sdk.Int{}, err
 		}
 		withdrawalAmt = maxTransferableAmount
 	case housetypes.WithdrawalMode_WITHDRAWAL_MODE_PARTIAL:
 		if maxTransferableAmount.LT(amount) {
-			return withdrawalAmt, sdkerrors.Wrapf(types.ErrWithdrawalAmountIsTooLarge, ": got %s, max %s", amount, maxTransferableAmount)
+			return sdk.Int{}, sdkerrors.Wrapf(types.ErrWithdrawalAmountIsTooLarge, ": got %s, max %s", amount, maxTransferableAmount)
 		}
 		err := k.transferFundsFromModuleToUser(ctx, types.BookLiquidityName, depositorAddress, amount)
 		if err != nil {
-			return withdrawalAmt, err
+			return sdk.Int{}, err
 		}
 		withdrawalAmt = amount
 	default:
-		return withdrawalAmt, sdkerrors.Wrapf(housetypes.ErrInvalidMode, "%s", mode.String())
+		return sdk.Int{}, sdkerrors.Wrapf(housetypes.ErrInvalidMode, "%s", mode.String())
 	}
 
 	bp.CurrentRoundLiquidity = bp.CurrentRoundLiquidity.Sub(withdrawalAmt)
@@ -200,7 +201,7 @@ func (k Keeper) LiquidateBookParticipation(
 	if bp.CurrentRoundLiquidity.Sub(bp.CurrentRoundMaxLoss).LTE(sdk.ZeroInt()) {
 		boes, err := k.GetOddsExposuresByBook(ctx, bookUID)
 		if err != nil {
-			return withdrawalAmt, err
+			return sdk.Int{}, err
 		}
 		for _, boe := range boes {
 			for i, pn := range boe.FulfillmentQueue {


### PR DESCRIPTION
## Description

The payout calculation formula has different Multiplication and Divisions. as a result, using the `sdk.Dec ` is inevitable. The truncated values in the `Moneyline` and `Fractional` may lead to a large amount of deviation between the calculated payout profit and conversion back to the bet amount.
 
---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Modified Features

- [x] Payout calculation return type changed to `sdk.Dec`.
- [x] Order Book Bet Placement Uses the `sdk.Dec` for the calculations.


---

## Test Cases

- [x] `TestCalculateMoneylinePayout`
- [x] `TestCalculateFractionalPayout`
- [x]  `TestCalculateDecimalPayout`

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
---
