### PR TITLE
Fix/ OrderBook process bet Payout truncation

### DIFF
--- a/x/bet/keeper/place_bet.go
+++ b/x/bet/keeper/place_bet.go
@@ -49,7 +49,7 @@ func (k Keeper) PlaceBet(ctx sdk.Context, bet *types.Bet) error {
 	betID := stats.Count
 
 	betFulfillment, err := k.obKeeper.ProcessBetPlacement(
-		ctx, bet.UID, bet.SportEventUID, bet.OddsUID, bet.MaxLossMultiplier, payoutProfit,
+		ctx, bet.UID, bet.SportEventUID, bet.OddsUID, bet.MaxLossMultiplier, bet.Amount, payoutProfit,
 		bettorAddress, bet.BetFee, bet.OddsType, bet.OddsValue, betID,
 	)
 	if err != nil {

--- a/x/bet/types/expected_keepers.go
+++ b/x/bet/types/expected_keepers.go
@@ -35,7 +35,7 @@ type DVMKeeper interface {
 
 // OrderBookKeeper defines the expected interface needed to process bet placement
 type OrderBookKeeper interface {
-	ProcessBetPlacement(ctx sdk.Context, betUID, bookUID, oddsUID string, maxLossMultiplier sdk.Dec, payoutProfit sdk.Dec, bettorAddress sdk.AccAddress, betFee sdk.Int, oddsType OddsType, oddsVal string, betID uint64) ([]*BetFulfillment, error)
+	ProcessBetPlacement(ctx sdk.Context, betUID, bookUID, oddsUID string, maxLossMultiplier sdk.Dec, betAmount sdk.Int, payoutProfit sdk.Dec, bettorAddress sdk.AccAddress, betFee sdk.Int, oddsType OddsType, oddsVal string, betID uint64) ([]*BetFulfillment, error)
 	RefundBettor(ctx sdk.Context, bettorAddress sdk.AccAddress, betAmount, payout sdk.Int, uniqueLock string) error
 	BettorWins(ctx sdk.Context, bettorAddress sdk.AccAddress, betAmount, payout sdk.Int, uniqueLock string, fulfillment []*BetFulfillment, bookUID string) error
 	BettorLoses(ctx sdk.Context, bettorAddress sdk.AccAddress, betAmount, payout sdk.Int, uniqueLock string, fulfillment []*BetFulfillment, bookUID string) error

--- a/x/bet/types/kyc.pb.go
+++ b/x/bet/types/kyc.pb.go
@@ -25,7 +25,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // KycDataPayload is the KYC info.
 type KycDataPayload struct {
-	// ignored is true if kyc validation is not required.
+	// ignore is true if kyc validation is not required.
 	Ignore bool `protobuf:"varint,1,opt,name=ignore,proto3" json:"ignore,omitempty"`
 	// approved represent if kvc validation is approved or not.
 	Approved bool `protobuf:"varint,2,opt,name=approved,proto3" json:"approved,omitempty"`

--- a/x/bet/types/payout_test.go
+++ b/x/bet/types/payout_test.go
@@ -28,7 +28,6 @@ func TestCalculateDecimalPayout(t *testing.T) {
 
 			expVal: 19594183,
 		},
-
 		{
 			desc:      "same",
 			oddsValue: "1",
@@ -111,6 +110,13 @@ func TestCalculateFractionalPayout(t *testing.T) {
 			expVal: 2095634,
 		},
 		{
+			desc:      "positive outcome 4",
+			oddsValue: "7/3",
+			betAmount: defaultBetAmount,
+
+			expVal: 83126841,
+		},
+		{
 			desc:      "same",
 			oddsValue: "1/1",
 			betAmount: defaultBetAmount,
@@ -183,7 +189,38 @@ func TestCalculateFractionalPayout(t *testing.T) {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount.Ceil().RoundInt()).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount)
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount.Ceil().RoundInt()).Abs().LTE(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount)
+			}
+		})
+	}
+}
+
+func TestCalculateFractionalBetAmount(t *testing.T) {
+	tcs := []struct {
+		desc         string
+		oddsValue    string
+		payoutProfit sdk.Dec
+
+		expVal sdk.Dec
+		err    error
+	}{
+		{
+			desc:         "positive outcome",
+			oddsValue:    "2/7",
+			payoutProfit: sdk.MustNewDecFromStr("5003"),
+
+			expVal: sdk.MustNewDecFromStr("17510.5"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_FRACTIONAL, tc.oddsValue, tc.payoutProfit)
+			if tc.err != nil {
+				require.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expVal, calcBetAmount, "expected: %d, actual: %d", tc.expVal, calcBetAmount)
 			}
 		})
 	}
@@ -210,7 +247,7 @@ func TestCalculateMoneylinePayout(t *testing.T) {
 			oddsValue: "-450",
 			betAmount: defaultBetAmount,
 
-			expVal: 7916841,
+			expVal: 7916842,
 		},
 		{
 			desc:      "lower",
@@ -264,7 +301,38 @@ func TestCalculateMoneylinePayout(t *testing.T) {
 				require.ErrorIs(t, tc.err, err)
 			} else {
 				require.NoError(t, err)
-				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount.Ceil().TruncateInt()).Abs().LT(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount)
+				require.True(t, sdk.NewInt(tc.betAmount).Sub(calcBetAmount.Ceil().TruncateInt()).Abs().LTE(ecceptedTruncatedValue), "expected: %d, actual: %d", tc.betAmount, calcBetAmount)
+			}
+		})
+	}
+}
+
+func TestCalculateMoneylineBetAmount(t *testing.T) {
+	tcs := []struct {
+		desc         string
+		oddsValue    string
+		payoutProfit sdk.Dec
+
+		expVal sdk.Dec
+		err    error
+	}{
+		{
+			desc:         "positive outcome",
+			oddsValue:    "-450",
+			payoutProfit: sdk.MustNewDecFromStr("5003"),
+
+			expVal: sdk.MustNewDecFromStr("22513.5"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			calcBetAmount, err := types.CalculateBetAmount(types.OddsType_ODDS_TYPE_MONEYLINE, tc.oddsValue, tc.payoutProfit)
+			if tc.err != nil {
+				require.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expVal, calcBetAmount, "expected: %d, actual: %d", tc.expVal, calcBetAmount)
 			}
 		})
 	}

--- a/x/orderbook/keeper/bet_place.go
+++ b/x/orderbook/keeper/bet_place.go
@@ -106,10 +106,6 @@ func (k Keeper) ProcessBetPlacement(
 		processBetFulfillment := func(payoutToFulfill sdk.Int, isLastFulfillment bool) error {
 			var betAmountToFulfill sdk.Int
 			if isLastFulfillment {
-				// subtract the sum of amounts ofprevious fulfillments
-				for _, f := range betFulfillments {
-					betAmount = betAmount.Sub(f.BetAmount)
-				}
 				// the bet amount
 				betAmountToFulfill = betAmount
 			} else {
@@ -153,6 +149,7 @@ func (k Keeper) ProcessBetPlacement(
 				BetAmount:          betAmountToFulfill,
 				PayoutAmount:       payoutToFulfill,
 			})
+			betAmount.Sub(betAmountToFulfill)
 
 			fulfiledBetAmount = fulfiledBetAmount.Add(betAmountToFulfill)
 			remainingPayoutProfit = remainingPayoutProfit.Sub(payoutToFulfill.ToDec())

--- a/x/orderbook/keeper/bet_place.go
+++ b/x/orderbook/keeper/bet_place.go
@@ -149,7 +149,7 @@ func (k Keeper) ProcessBetPlacement(
 				BetAmount:          betAmountToFulfill,
 				PayoutAmount:       payoutToFulfill,
 			})
-			betAmount.Sub(betAmountToFulfill)
+			betAmount = betAmount.Sub(betAmountToFulfill)
 
 			fulfiledBetAmount = fulfiledBetAmount.Add(betAmountToFulfill)
 			remainingPayoutProfit = remainingPayoutProfit.Sub(payoutToFulfill.ToDec())

--- a/x/orderbook/keeper/bet_place.go
+++ b/x/orderbook/keeper/bet_place.go
@@ -255,12 +255,12 @@ func (k Keeper) ProcessBetPlacement(
 		}
 
 		// if the remaining payout is less than 1.00, means that the decimal part will be ignored
-		if remainingPayoutProfit.LTE(sdk.OneDec()) || len(updatedFulfillmentQueue) == 0 {
+		if remainingPayoutProfit.LT(sdk.OneDec()) || len(updatedFulfillmentQueue) == 0 {
 			break
 		}
 	}
 
-	if remainingPayoutProfit.GT(sdk.OneDec()) {
+	if remainingPayoutProfit.GTE(sdk.OneDec()) {
 		return betFulfillments, sdkerrors.Wrapf(types.ErrInternalProcessingBet, "insufficient liquidity in order book")
 	}
 


### PR DESCRIPTION
## Description

The calculations of the bet amount and payouts in the processing of the payout and participations need to be redesigned to make the calculations more accurate.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Modified Features

- [x] Orderbook `ProcessBetPlacement`
- [x] Odds type payout calculations

---

## Test Cases

- [x] `TestCalculateDecimalPayout`
- [x] `TestCalculateFractionalPayout`
- [x] `TestCalculateFractionalBetAmount`
- [x] `TestCalculateMoneylinePayout`
- [x] `TestCalculateMoneylineBetAmount`

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
---
