### PR TITLE
Fix/ Order book query wrong command

### DIFF
--- a/x/strategicreserve/client/cli/query_orderbook.go
+++ b/x/strategicreserve/client/cli/query_orderbook.go
@@ -59,13 +59,13 @@ $ %s query strategicreserve orderbooks
 // GetCmdQueryOrderBook implements the strategicreserve query command.
 func GetCmdQueryOrderBook() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "strategicreserve [order-book-id]",
+		Use:   "orderbook [order-book-id]",
 		Short: "Query a strategicreserve",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Query details about a order book.
 
 Example:
-$ %s query strategicreserve strategicreserve %s
+$ %s query strategicreserve orderbook %s
 `,
 				version.AppName, "5531c60f-2025-48ce-ae79-1dc110f16000",
 			),


### PR DESCRIPTION
## Description

Single order book query command was wrongly set as `strategicreserve`. This PR is going to fix this.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Modified Features

- [x] `strategicreserve orderbook` command fix

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
---
