### PR TITLE
Fix / Incorrect Setting of `SpendLimit` in `DepositAuthorization`

### DIFF
--- a/x/house/types/deposit_authorizaton.go
+++ b/x/house/types/deposit_authorizaton.go
@@ -27,16 +27,20 @@ func (a DepositAuthorization) Accept(ctx sdk.Context, msg sdk.Msg) (authz.Accept
 		return authz.AcceptResponse{}, sdkerrors.ErrInvalidType.Wrap("type mismatch")
 	}
 
-	if a.SpendLimit.LT(mDeposit.Amount) {
+	limitLeft := a.SpendLimit.Sub(mDeposit.Amount)
+	if limitLeft.IsNegative() {
 		return authz.AcceptResponse{}, sdkerrors.ErrInsufficientFunds.Wrapf(
 			"requested amount is more than spend limit",
 		)
+	}
+	if limitLeft.IsZero() {
+		return authz.AcceptResponse{Accept: true, Delete: true}, nil
 	}
 
 	return authz.AcceptResponse{
 		Accept:  true,
 		Delete:  false,
-		Updated: &DepositAuthorization{SpendLimit: mDeposit.Amount},
+		Updated: &DepositAuthorization{SpendLimit: limitLeft},
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Update spend limit value in `Accept` method of the deposit authorization.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Added Features

- [ ]

---

## Modified Features

- [x] Deposit authorization `Accept` method
 
---

## Test Cases

- [ ] Test A
- [ ] Test B

---

## Change Log

---

## Documentation


---

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
---
