### PR TITLE
(patch) Fix injection vulnerability

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -9,7 +9,7 @@ env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
   NPM_VERSION: patch
 
-
+permissions: read-all
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -63,13 +63,15 @@ jobs:
         git -C sgejs commit --allow-empty -am "Codegen Deployment [skip ci]"
 
     - name: Determine NPM version
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
         cd sgejs
-        if [[ "${{ github.event.pull_request.title }}" == *"major"* ]]; then
+        if [[ "$PR_TITLE" == *"major"* ]]; then
           echo "NPM_VERSION=major" >> $GITHUB_ENV
-        elif [[ "${{ github.event.pull_request.title }}" == *"minor"* ]]; then
+        elif [[ "$PR_TITLE" == *"minor"* ]]; then
           echo "NPM_VERSION=minor" >> $GITHUB_ENV
-        elif [[ "${{ github.event.pull_request.title }}" == *"patch"* ]]; then
+        elif [[ "$PR_TITLE" == *"patch"* ]]; then
           echo "NPM_VERSION=patch" >> $GITHUB_ENV
         fi
 


### PR DESCRIPTION
## Description

This fixes a security vulnerability allowing anyone to create a malicious issue and steal the GITHUB_TOKEN and ST_TOKEN. Someone who did not know what they were doing tried to attack this repo earlier (see https://github.com/sge-network/sge/pull/214), so the "cat is out of the bag" and getting this fixed is important before someone causes harm.

This PR fixes the injection and reduces the workflow permissions to read-only (the only git push actions involve the ST_TOKEN PAT, so it is ok if the workflow GITHUB_TOKEN only has read permissions.

See https://cycode.com/blog/github-actions-vulnerabilities/ for how this vulnerability works.

---

## Type of change

Please check the options that are relevant. This PR introduces

- [x] Bug fix (non-breaking change which fixes an existing issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added change type (major|minor|patch) in the PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
---
