### PR TITLE
Fix / Change min count of OVM keys to 4

### DIFF
--- a/x/ovm/types/consts.go
+++ b/x/ovm/types/consts.go
@@ -17,7 +17,7 @@ const (
 	DefaultTimeWeight = 1
 
 	// MinPubKeysCount is the minimum allowed public keys in the key vault
-	MinPubKeysCount = 3
+	MinPubKeysCount = 4
 
 	// MaxPubKeysCount is the maximum allowed public keys in the key vault
 	MaxPubKeysCount = 5


### PR DESCRIPTION
## Description

The minimum allowed count of OVM keys changed to `4`.

---

## Type of change

Please check the options that are relevant. This PR introduces

- [ ] Bug fix (non-breaking change which fixes an existing issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Features Description

- [ ] NA

---

## Test Cases

- [ ] NA

---


## Documentation


---

## Checklist:

- [ ] I have added change type (major|minor|patch) in the PR
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
---
