### PR TITLE
Fix / Requeue validation removal

### DIFF
--- a/x/orderbook/keeper/bet_wager.go
+++ b/x/orderbook/keeper/bet_wager.go
@@ -191,15 +191,14 @@ func (k Keeper) initFulfillmentInfo(
 ) {
 	fInfo = fulfillmentInfo{
 		// bet specs
-		betAmount:               betAmount,
-		payoutProfit:            payoutProfit,
-		betUID:                  betUID,
-		betID:                   betID,
-		oddsUID:                 oddsUID,
-		oddsType:                oddsType,
-		oddsVal:                 oddsVal,
-		maxLossMultiplier:       maxLossMultiplier,
-		totalAvailableLiquidity: sdk.NewInt(0),
+		betAmount:         betAmount,
+		payoutProfit:      payoutProfit,
+		betUID:            betUID,
+		betID:             betID,
+		oddsUID:           oddsUID,
+		oddsType:          oddsType,
+		oddsVal:           oddsVal,
+		maxLossMultiplier: maxLossMultiplier,
 
 		//  in process maps
 		fulfillmentMap: make(map[uint64]fulfillmentItem),
@@ -237,9 +236,6 @@ func (k Keeper) initFulfillmentInfo(
 		if found {
 			item.participationExposure = pe
 			fInfo.fulfillmentMap[pe.ParticipationIndex] = item
-
-			fInfo.totalAvailableLiquidity = fInfo.totalAvailableLiquidity.
-				Add(item.calcAvailableLiquidity(maxLossMultiplier))
 		}
 	}
 
@@ -269,15 +265,6 @@ func (fInfo *fulfillmentInfo) validate() error {
 				participationIndex,
 			)
 		}
-	}
-
-	if fInfo.totalAvailableLiquidity.LT(fInfo.payoutProfit.TruncateInt()) {
-		return sdkerrors.Wrapf(
-			types.ErrInsufficientFundToCoverPayout,
-			"total liquidity %s, payout %s",
-			fInfo.totalAvailableLiquidity,
-			fInfo.payoutProfit,
-		)
 	}
 
 	return nil
@@ -417,16 +404,15 @@ func (k Keeper) refreshQueueAndState(
 }
 
 type fulfillmentInfo struct {
-	betUID                  string
-	betID                   uint64
-	oddsUID                 string
-	oddsType                bettypes.OddsType
-	oddsVal                 string
-	maxLossMultiplier       sdk.Dec
-	betAmount               sdkmath.Int
-	payoutProfit            sdk.Dec
-	fulfilledBetAmount      sdkmath.Int
-	totalAvailableLiquidity sdkmath.Int
+	betUID             string
+	betID              uint64
+	oddsUID            string
+	oddsType           bettypes.OddsType
+	oddsVal            string
+	maxLossMultiplier  sdk.Dec
+	betAmount          sdkmath.Int
+	payoutProfit       sdk.Dec
+	fulfilledBetAmount sdkmath.Int
 
 	fulfillmentQueue []uint64
 	fulfillmentMap   fulfillmentMap

--- a/x/orderbook/keeper/bet_wager_test.go
+++ b/x/orderbook/keeper/bet_wager_test.go
@@ -248,7 +248,7 @@ func (ts *testBetSuite) placeBetsAndTest() ([]bettypes.Bet, sdk.Dec, sdk.Dec) {
 		failedWinnerBetID,
 		sdk.NewInt(100000000000),
 		ts.betFee,
-		types.ErrInsufficientFundToCoverPayout,
+		types.ErrInternalProcessingBet,
 	)
 
 	///// loser bet placement

--- a/x/orderbook/keeper/orderbook_settle_test.go
+++ b/x/orderbook/keeper/orderbook_settle_test.go
@@ -73,10 +73,16 @@ func TestOrderBookSettlement(t *testing.T) {
 			Sub(ts.participations[1].Fee),
 		participant2BalanceAfterSettlement)
 
+	// In this case, in the orderbook we have a long loop of requeue
+	// and the payout is a large value.
+	// in the real scenario when the bet placement transaction fails duo to
+	// orderbook failure, the hole transaction would fail and no state change will happen.
 	participant3BalanceAfterSettlement := ts.tApp.BankKeeper.GetBalance(
 		ts.ctx, sdk.MustAccAddressFromBech32(ts.deposits[2].DepositorAddress),
 		params.DefaultBondDenom).Amount
 	require.Equal(t,
-		participant3BalanceBeforeDeposit.Int64(),
-		participant3BalanceAfterSettlement.Int64())
+		participant3BalanceBeforeDeposit.
+			// subtract participation fee
+			Sub(ts.participations[2].Fee),
+		participant3BalanceAfterSettlement)
 }

--- a/x/orderbook/types/errors.go
+++ b/x/orderbook/types/errors.go
@@ -31,7 +31,6 @@ var (
 	ErrMaxWithdrawableAmountIsZero        = sdkerrors.Register(ModuleName, 6021, "maximum withdrawal amount is zero")
 	ErrParticipationOnInactiveMarket      = sdkerrors.Register(ModuleName, 6022, "participation is allowed on an active market only")
 	ErrMarketNotFound                     = sdkerrors.Register(ModuleName, 6023, "market not found to initialize participation")
-	ErrInsufficientFundToCoverPayout      = sdkerrors.Register(ModuleName, 6024, "insufficient fund in the participations to cover the payout")
 	ErrUnknownMarketStatus                = sdkerrors.Register(ModuleName, 6025, "unknown market status of orderbook settlement")
 	ErrWithdrawalTooLarge                 = sdkerrors.Register(ModuleName, 6026, "withdrawal is more than unused amount")
 )


### PR DESCRIPTION
## Description

There is a validation at the beginning of the `processWager` method of the `orderbook` module. This validation does not support scenarios of requeue and refreshing the queue for the next round of processing.

Removal of the validation allows the order book process to be able to use subtracted amount of current round liquidity and `maxloss` in the calulcations.

Also, This may lead to a more (unnecessary) execution process in the requeue happening.

---

## Type of change

Please check the options that are relevant. This PR introduces

- [x] Patch: Bug fix (non-breaking change which fixes an existing issue)
- [x] Minor: New feature (non-breaking change which adds new functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Features Description

- [ ] Process Wager validation

---

## Test Cases

- [ ] Orderbook settlement

---


## Documentation


---

## Checklist:

- [ ] I have added change type (major|minor|patch) in the PR
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
---
