### PR TITLE
Feature / Replace unlock period with unlock timestamp in reward events

### DIFF
--- a/docs/specs/Reward/07_Events.md
+++ b/docs/specs/Reward/07_Events.md
@@ -48,7 +48,7 @@ The Bet module emits the following events
 | apply_reward               | promoter                  | {promoter}                       |
 | apply_reward               | main_acc_amount           | {main_acc_amount}                |
 | apply_reward               | sub_acc_amount            | {sub_acc_amount}                 |
-| apply_reward               | sub_acc_unlock_period     | {sub_acc_unlock_period}          |
+| apply_reward               | sub_acc_unlock_ts         | {sub_acc_unlock_ts}              |
 | message                    | module                    | reward                           |
 | message                    | action                    | apply_reward                     |
 | message                    | sender                    | {creator}                        |

--- a/x/reward/keeper/msg_server_reward.go
+++ b/x/reward/keeper/msg_server_reward.go
@@ -58,7 +58,8 @@ func (k msgServer) GrantReward(goCtx context.Context, msg *types.MsgGrantReward)
 		return nil, types.ErrInsufficientPoolBalance
 	}
 
-	if err := k.DistributeRewards(ctx, receiver); err != nil {
+	unlockTS, err := k.DistributeRewards(ctx, receiver)
+	if err != nil {
 		return nil, sdkerrors.Wrapf(types.ErrInDistributionOfRewards, "%s", err)
 	}
 
@@ -72,7 +73,7 @@ func (k msgServer) GrantReward(goCtx context.Context, msg *types.MsgGrantReward)
 	k.SetRewardByReceiver(ctx, types.NewRewardByCategory(msg.Uid, receiver.MainAccountAddr, campaign.RewardCategory))
 	k.SetRewardByCampaign(ctx, types.NewRewardByCampaign(msg.Uid, campaign.UID))
 
-	msg.EmitEvent(&ctx, msg.CampaignUid, msg.Uid, campaign.Promoter, *campaign.RewardAmount, receiver)
+	msg.EmitEvent(&ctx, msg.CampaignUid, msg.Uid, campaign.Promoter, *campaign.RewardAmount, receiver, unlockTS)
 
 	return &types.MsgGrantRewardResponse{}, nil
 }

--- a/x/reward/types/events.go
+++ b/x/reward/types/events.go
@@ -9,5 +9,5 @@ const (
 	attributeKeyRewardPromoter = "promoter"
 	attributeKeyMainAmount     = "main_acc_amount"
 	attributeKeySubAmount      = "sub_acc_amount"
-	attributeKeyUnlockPeriod   = "sub_acc_unlock_period"
+	attributeKeyUnlockTS       = "sub_acc_unlock_ts"
 )

--- a/x/reward/types/messages_reward.go
+++ b/x/reward/types/messages_reward.go
@@ -70,7 +70,7 @@ func (msg *MsgGrantReward) ValidateBasic() error {
 
 // EmitEvent emits the event for the message success.
 func (msg *MsgGrantReward) EmitEvent(ctx *sdk.Context, campaignUID string,
-	rewardUID, promoterAddr string, rewardAmount RewardAmount, recevier Receiver,
+	rewardUID, promoterAddr string, rewardAmount RewardAmount, receiver Receiver, subAccUnlockTS uint64,
 ) {
 	mainAmount := sdkmath.ZeroInt()
 	if !rewardAmount.MainAccountAmount.IsNil() {
@@ -88,8 +88,8 @@ func (msg *MsgGrantReward) EmitEvent(ctx *sdk.Context, campaignUID string,
 		sdk.NewAttribute(attributeKeyRewardPromoter, promoterAddr),
 		sdk.NewAttribute(attributeKeyMainAmount, mainAmount.String()),
 		sdk.NewAttribute(attributeKeySubAmount, subAmount.String()),
-		sdk.NewAttribute(attributeKeyUnlockPeriod, cast.ToString(rewardAmount.UnlockPeriod)),
-		sdk.NewAttribute(attributeKeyReceiver, recevier.String()),
+		sdk.NewAttribute(attributeKeyUnlockTS, cast.ToString(subAccUnlockTS)),
+		sdk.NewAttribute(attributeKeyReceiver, receiver.String()),
 	)
 	emitter.Emit()
 }


### PR DESCRIPTION
## Description

Replace the unlock period (The delta with block time) to unlock time stamp in the `MsgGrantReward` events.

---

## Type of change

Please check the options that are relevant. This PR introduces

- [ ] Patch: Bug fix (non-breaking change which fixes an existing issue)
- [ ] Minor: New feature (non-breaking change which adds new functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Features Description

- [x] `MsgGrantReward` emit event
- [x] `DistributeReward` method

---

## Test Cases

- [ ] NA

---


## Documentation


---

## Checklist:

- [ ] I have added change type (major|minor|patch) in the PR
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
---
