### PR TITLE
Release / v1.7.2

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -82,6 +82,8 @@ var (
 		v9.Upgrade,
 		v10.Upgrade,
 	}
+	// default wasmd binary maximum allowed size
+	defaultMaxWasmSize = 1500 * 1024 // 1.5 MB
 )
 
 var (
@@ -172,6 +174,8 @@ func NewSgeApp(
 		// https://github.com/CosmWasm/wasmd#compile-time-parameters
 		val, _ := strconv.ParseInt(maxSize, 10, 32)
 		wasmtypes.MaxWasmSize = int(val)
+	} else {
+		wasmtypes.MaxWasmSize = defaultMaxWasmSize
 	}
 
 	// NOTE: we may consider parsing `appOpts` inside module constructors. For the moment

--- a/app/upgrades/v10/consts.go
+++ b/app/upgrades/v10/consts.go
@@ -6,8 +6,8 @@ import (
 	"github.com/sge-network/sge/app/upgrades"
 )
 
-// UpgradeName defines the on-chain upgrade name for the v1.7.1 upgrade.
-const UpgradeName = "v1.7.1"
+// UpgradeName defines the on-chain upgrade name for the v1.7.2 upgrade.
+const UpgradeName = "v1.7.2"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,


### PR DESCRIPTION
## Description

Added fix for query of rewards to support per-account. the default wasm binary size increased to 1.5mb.

---

## Type of change

Please check the options that are relevant. This PR introduces

- [x] Patch: Bug fix (non-breaking change which fixes an existing issue)
- [x] Minor: New feature (non-breaking change which adds new functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Features Description

- [x] Query for per-account reward
- [x] `wasmd` max binary size default value. 

---

## Test Cases

- [ ] NA

---


## Documentation


---

## Checklist:

- [x] I have added change type (major|minor|patch) in the PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
---
